### PR TITLE
Add wp-mail config option for default installation mail

### DIFF
--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -345,7 +345,8 @@ class WordPress extends EE_Site_Command {
 			$this->site_data['db_port'] = empty( $arg_host_port[1] ) ? '3306' : $arg_host_port[1];
 		}
 
-		$this->site_data['app_admin_email'] = \EE\Utils\get_flag_value( $assoc_args, 'admin-email', strtolower( 'admin@' . $this->site_data['site_url'] ) );
+		$default_email                      = \EE::get_runner()->config['wp-mail'] ?? 'admin@' . $this->site_data['site_url'];
+		$this->site_data['app_admin_email'] = \EE\Utils\get_flag_value( $assoc_args, 'admin-email', strtolower( $default_email ) );
 		$this->skip_install                 = \EE\Utils\get_flag_value( $assoc_args, 'skip-install' );
 		$this->skip_status_check            = \EE\Utils\get_flag_value( $assoc_args, 'skip-status-check' );
 		$this->force                        = \EE\Utils\get_flag_value( $assoc_args, 'force' );


### PR DESCRIPTION
Depends on https://github.com/EasyEngine/easyengine/pull/1454

Signed-off-by: Riddhesh Sanghvi <riddhesh237@gmail.com>