### PR TITLE
Add sysctl parameters in site type WP

### DIFF
--- a/src/Site_WP_Docker.php
+++ b/src/Site_WP_Docker.php
@@ -61,6 +61,7 @@ class Site_WP_Docker {
 					[ 'name' => 'MYSQL_PASSWORD' ],
 				],
 			];
+			$db['sysctls']      = sysctl_parameters();
 			$db['networks']     = $network_default;
 		}
 		// PHP configuration.
@@ -224,6 +225,7 @@ class Site_WP_Docker {
 				'name' => 'io.easyengine.site=${VIRTUAL_HOST}',
 			],
 		];
+		$redis['sysctls']      = sysctl_parameters();
 		$redis['networks']     = $network_default;
 
 		$base[] = $php;

--- a/src/Site_WP_Docker.php
+++ b/src/Site_WP_Docker.php
@@ -4,6 +4,7 @@ namespace EE\Site\Type;
 
 use function EE\Utils\mustache_render;
 use function EE\Site\Utils\get_ssl_policy;
+use function EE\Site\Utils\sysctl_parameters;
 
 class Site_WP_Docker {
 
@@ -101,6 +102,8 @@ class Site_WP_Docker {
 			],
 		];
 
+		$php['sysctls']  = sysctl_parameters();
+
 		$php['networks'] = [
 			'net' => [
 				[
@@ -160,6 +163,9 @@ class Site_WP_Docker {
 				'name' => 'io.easyengine.site=${VIRTUAL_HOST}',
 			],
 		];
+
+		$nginx['sysctls'] = sysctl_parameters();
+
 		$nginx['networks'] = [
 			'net' => [
 				[ 'name' => 'global-frontend-network' ],

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -42,6 +42,12 @@ services:
       - {{name}}
     {{/env}}
     {{/environment}}
+    {{#sysctls}}
+    sysctls:
+    {{#sysctl}}
+      - {{name}}
+    {{/sysctl}}
+    {{/sysctls}}
     external_links:
       - services_global-nginx-proxy_1:${VIRTUAL_HOST}
     {{#networks}}


### PR DESCRIPTION
Ref: https://github.com/EasyEngine/feature-requests/issues/88

Signed-off-by: dhsathiya <devarshisathiya5@gmail.com>