### PR TITLE
Update vip site setup for public-dir changes

### DIFF
--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -1138,7 +1138,7 @@ class WordPress extends EE_Site_Command {
 		}
 
 		if ( $this->is_vip ) {
-			$extra_php .= "\n\nif ( file_exists( ABSPATH . \"/wp-content/vip-config/vip-config.php\" ) ) {\n	require_once( ABSPATH . \"/wp-content/vip-config/vip-config.php\" );\n}";
+			$extra_php .= "\n\nif ( file_exists( ABSPATH . '/wp-content/vip-config/vip-config.php' ) ) {\n	require_once( ABSPATH . '/wp-content/vip-config/vip-config.php' );\n}";
 		}
 
 		$db_host                  = isset( $this->site_data['db_port'] ) ? $this->site_data['db_host'] . ':' . $this->site_data['db_port'] : $this->site_data['db_host'];

--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -1138,7 +1138,7 @@ class WordPress extends EE_Site_Command {
 		}
 
 		if ( $this->is_vip ) {
-			$extra_php .= "\n\nif ( file_exists( __DIR__ . \"/htdocs/wp-content/vip-config/vip-config.php\" ) ) {\n		require_once( __DIR__ . \"/htdocs/wp-content/vip-config/vip-config.php\" ); \n}";
+			$extra_php .= "\n\nif ( file_exists( ABSPATH . \"/wp-content/vip-config/vip-config.php\" ) ) {\n	require_once( ABSPATH . \"/wp-content/vip-config/vip-config.php\" );\n}";
 		}
 
 		$db_host                  = isset( $this->site_data['db_port'] ) ? $this->site_data['db_host'] . ':' . $this->site_data['db_port'] : $this->site_data['db_host'];

--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -1131,10 +1131,10 @@ class WordPress extends EE_Site_Command {
 		}
 
 		// Added wp-config.php debug constants referred from https://codex.wordpress.org/Debugging_in_WordPress.
-		$extra_php = "if ( isset( \$_SERVER[\"HTTP_X_FORWARDED_PROTO\"] ) && \$_SERVER[\"HTTP_X_FORWARDED_PROTO\"] == \"https\" ) {\n	\$_SERVER[\"HTTPS\"] = \"on\";\n}\n\n// Enable WP_DEBUG mode.\ndefine( \"WP_DEBUG\", false );\n\n// Enable Debug logging to the /wp-content/debug.log file\ndefine( \"WP_DEBUG_LOG\", false );\n\n// Disable display of errors and warnings.\ndefine( \"WP_DEBUG_DISPLAY\", false );\n@ini_set( \"display_errors\", 0 );\n\n// Use dev versions of core JS and CSS files (only needed if you are modifying these core files)\ndefine( \"SCRIPT_DEBUG\", false );";
+		$extra_php = 'if ( isset( \$_SERVER[\'HTTP_X_FORWARDED_PROTO\'] ) && \$_SERVER[\'HTTP_X_FORWARDED_PROTO\'] == \'https\' ) {' . "\n" . '	\$_SERVER[\'HTTPS\'] = \'on\';' . "\n}\n\n" . '// Enable WP_DEBUG mode.' . "\n" . 'define( \'WP_DEBUG\', false );' . "\n\n" . '// Enable Debug logging to the /wp-content/debug.log file' . "\n" . 'define( \'WP_DEBUG_LOG\', false );' . "\n\n" . '// Disable display of errors and warnings.' . "\n" . 'define( \'WP_DEBUG_DISPLAY\', false );' . "\n" . '@ini_set( \'display_errors\', 0 );' . "\n\n" . '// Use dev versions of core JS and CSS files (only needed if you are modifying these core files)' . "\n" . 'define( \'SCRIPT_DEBUG\', false );';
 
 		if ( 'wp' !== $this->site_data['app_sub_type'] ) {
-			$extra_php .= "\n\n// Disable cookie domain.\ndefine( \"COOKIE_DOMAIN\", false );";
+			$extra_php .= "\n\n// Disable cookie domain.\ndefine( 'COOKIE_DOMAIN', false );";
 		}
 
 		if ( $this->is_vip ) {
@@ -1142,7 +1142,7 @@ class WordPress extends EE_Site_Command {
 		}
 
 		$db_host                  = isset( $this->site_data['db_port'] ) ? $this->site_data['db_host'] . ':' . $this->site_data['db_port'] : $this->site_data['db_host'];
-		$wp_config_create_command = sprintf( 'docker-compose exec --user=\'www-data\' php wp config create --dbuser=\'%s\' --dbname=\'%s\' --dbpass=\'%s\' --dbhost=\'%s\' %s --extra-php=\'%s\'', $this->site_data['db_user'], $this->site_data['db_name'], $this->site_data['db_password'], $db_host, $config_arguments, $extra_php );
+		$wp_config_create_command = sprintf( 'docker-compose exec --user=\'www-data\' php wp config create --dbuser=\'%s\' --dbname=\'%s\' --dbpass=\'%s\' --dbhost=\'%s\' %s --extra-php="%s"', $this->site_data['db_user'], $this->site_data['db_name'], $this->site_data['db_password'], $db_host, $config_arguments, $extra_php );
 
 		try {
 			if ( ! \EE::exec( $wp_config_create_command ) ) {

--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -1039,7 +1039,8 @@ class WordPress extends EE_Site_Command {
 			}
 		}
 
-		$wp_root_dir = $this->site_data['site_fs_path'] . '/app/htdocs';
+		$public_dir_path = get_public_dir( $assoc_args );
+		$wp_root_dir     = $this->site_data['site_fs_path'] . '/app/htdocs/' . str_replace( '/var/www/htdocs', '', $public_dir_path );
 
 		if ( $this->is_vip && file_exists( $wp_root_dir . '/mu-plugins' ) ) {
 			// Enable VIP MU plugins.
@@ -1047,7 +1048,7 @@ class WordPress extends EE_Site_Command {
 		}
 
 		// Reset wp-content permission which may have been changed during git clone from host machine.
-		EE::exec( "docker-compose exec --user=root php chown -R www-data: /var/www/htdocs/wp-content" );
+		EE::exec( "docker-compose exec --user=root php chown -R www-data: $public_dir_path/wp-content" );
 
 		$this->create_site_db_entry();
 		\EE::log( 'Site entry created.' );
@@ -1276,7 +1277,8 @@ class WordPress extends EE_Site_Command {
 
 		\EE::log( "Setting up VIP Go environment. This may take time based on your repo size, please wait for a while..." );
 
-		$site_wp_root_dir = $this->site_data['site_fs_path'] . '/app/htdocs';
+		$public_dir_path  = get_public_dir( $assoc_args );
+		$site_wp_root_dir = $this->site_data['site_fs_path'] . '/app/htdocs/' . str_replace( '/var/www/htdocs', '', $public_dir_path );
 
 		chdir( $site_wp_root_dir );
 


### PR DESCRIPTION
1. Fixes including `vip-config.php` in `wp-config.php` file when `--public-dir` parameter is passed.
2. Fixes proper cloning of vip files inside the folder passed in `--public-dir`.
3. Minor updates in defining constants in `wp-config.php`, convert double quotes to single quotes.