### PR TITLE
Make ee compatible with PHP 8.0

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -380,7 +380,7 @@ class FeatureContext implements Context
 	public function thereShouldBeContainersWithLabel($expected_running_containers, PyStringNode $pyStringNode)
 	{
 		$labels = $pyStringNode->getStrings();
-		$label_string = implode($labels, ' -f label=');
+		$label_string = implode(' -f label=', $labels);
 
 		$result = EE::launch( "docker ps -qf label=$label_string | wc -l", false, true );
 		$running_containers = (int) trim($result->stdout);


### PR DESCRIPTION
This PR is necessary for `ee` so it can be run with PHP 8.0.