### PR TITLE
Add WebP MIME type to Nginx main config

### DIFF
--- a/templates/config/nginx/main.conf.mustache
+++ b/templates/config/nginx/main.conf.mustache
@@ -10,6 +10,14 @@ upstream redis {
 	server {{cache_host}}:6379;
 	keepalive 10;
 }
+types {
+    image/webp  webp;
+    image/jpeg  jpeg jpg;
+    image/png   png;
+}
+index index.php index.html index.htm;
+
+
 {{/include_redis_conf}}
 
 server {


### PR DESCRIPTION
### What does this PR do?
Adds WebP MIME type support to EasyEngine's Nginx configuration for WordPress.

### Why is this needed?
To allow browsers to load modern `.webp` images, improving performance.

### How to test?
1. Deploy a site with EasyEngine
2. Upload a `.webp` file to `htdocs`
3. Visit in browser or `curl` and confirm `Content-Type: image/webp`

### Fixes
Fixes EasyEngine/easyengine#1655
