### PR TITLE
feat(php): update default PHP version to 8.3

### DIFF
--- a/src/Site_WP_Docker.php
+++ b/src/Site_WP_Docker.php
@@ -67,7 +67,7 @@ class Site_WP_Docker {
 		}
 
 		// PHP configuration.
-		$php_image_key = ( 'latest' === $filters['php_version'] ? 'easyengine/php8.2' : 'easyengine/php' . $filters['php_version'] );
+		$php_image_key = ( 'latest' === $filters['php_version'] ? 'easyengine/php8.3' : 'easyengine/php' . $filters['php_version'] );
 
 		$php['service_name'] = [ 'name' => 'php' ];
 		$php['image']        = [ 'name' => $php_image_key . ':' . $img_versions[ $php_image_key ] ];

--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -133,7 +133,7 @@ class WordPress extends EE_Site_Command {
 	 * [--php=<php-version>]
 	 * : PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 and latest.
 	 * ---
-	 * default: 8.2
+	 * default: 8.3
 	 * options:
 	 *	- 5.6
 	 *	- 7.0
@@ -381,7 +381,7 @@ class WordPress extends EE_Site_Command {
 				$this->site_data['php_version'] = 7.4;
 				$old_version                    .= ' yet';
 			} elseif ( 8 === $floor ) {
-			$this->site_data['php_version'] = 8.2;
+			$this->site_data['php_version'] = 8.3;
 			$old_version .= ' yet';
 		} else {
 				EE::error( 'Unsupported PHP version: ' . $this->site_data['php_version'] );


### PR DESCRIPTION
This pull request updates the default PHP version used for new WordPress sites from 8.2 to 8.3. The change ensures that the latest stable PHP version is used in site creation and Docker configuration.

Updates to default PHP version:

* Changed the default PHP version in the CLI documentation and options from 8.2 to 8.3 in the `WordPress.php` constructor.
* Updated the logic in the site creation flow to set the default PHP version to 8.3 instead of 8.2 when PHP 8 is selected.

Docker configuration:

* Updated the Docker Compose configuration to use the `easyengine/php8.3` image instead of `easyengine/php8.2` when the "latest" PHP version is selected.