### PR TITLE
Add --skip-ssl option to db export command

### DIFF
--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -1439,7 +1439,7 @@ class WordPress extends EE_Site_Command {
 
 		EE::log( 'Running search-replace.' );
 		EE::log( 'Taking database backup before search-replace.' );
-		EE::exec( sprintf( \EE_DOCKER::docker_compose_with_custom() . ' exec php wp db export %s.db', $this->site_data['site_url'] ) );
+		EE::exec( sprintf( \EE_DOCKER::docker_compose_with_custom() . ' exec php wp db export --skip-ssl %s.db', $this->site_data['site_url'] ) );
 
 		$db_file         = $this->site_data['site_fs_path'] . '/app/htdocs/' . $this->site_data['site_url'] . '.db';
 		$backup_location = EE_BACKUP_DIR . '/' . $this->site_data['site_url'] . '/' . $this->site_data['site_url'] . '.db';


### PR DESCRIPTION
This pull request makes a small but important update to the database export process within the `update_ssl` method. The change ensures that SSL is skipped during the WordPress database export command, which can help avoid issues when exporting databases from environments with misconfigured or self-signed SSL certificates.

- Added the `--skip-ssl` flag to the `wp db export` command in the `update_ssl` method of the `WordPress.php` file to prevent SSL-related errors during database export.