### PR TITLE
feat(php): make PHP 8.4 the default version

### DIFF
--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -133,7 +133,7 @@ class WordPress extends EE_Site_Command {
 	 * [--php=<php-version>]
 	 * : PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 and latest.
 	 * ---
-	 * default: 8.3
+	 * default: 8.4
 	 * options:
 	 *	- 5.6
 	 *	- 7.0
@@ -305,7 +305,7 @@ class WordPress extends EE_Site_Command {
 		$this->cache_type                       = \EE\Utils\get_flag_value( $assoc_args, 'cache' );
 		$wildcard_flag                          = \EE\Utils\get_flag_value( $assoc_args, 'wildcard' );
 		$this->site_data['site_ssl_wildcard']   = 'subdom' === $this->site_data['app_sub_type'] || $wildcard_flag ? true : false;
-		$this->site_data['php_version']         = \EE\Utils\get_flag_value( $assoc_args, 'php', '8.2' );
+		$this->site_data['php_version']         = \EE\Utils\get_flag_value( $assoc_args, 'php' );
 		$this->site_data['app_admin_url']       = \EE\Utils\get_flag_value( $assoc_args, 'title', $this->site_data['site_url'] );
 		$this->site_data['app_admin_username']  = \EE\Utils\get_flag_value( $assoc_args, 'admin-user', \EE\Utils\random_name_generator() );
 		$this->site_data['app_admin_password']  = \EE\Utils\get_flag_value( $assoc_args, 'admin-pass', '' );


### PR DESCRIPTION
## Summary

Makes **PHP 8.4** the default version for new WordPress sites and removes a stale, dead default that had drifted out of sync.

Three places encode the PHP default, and they had diverged:

| Location | Before | Effective? |
|----------|--------|-----------|
| `--php` synopsis `default:` (`WordPress.php`) | `8.3` | ✅ yes — this is the real default WP-CLI applies |
| `--php` `get_flag_value()` fallback (`WordPress.php:308`) | `'8.2'` | ❌ dead — never runs |
| 8.x unsupported-version fallback (`WordPress.php:385`) | `8.4` | only on bad input |
| `latest` → image map (`Site_WP_Docker.php`) | `easyengine/php8.4` | for `latest` only |

`#235` already moved the 8.x fallback and the `latest` image tag to **8.4**, but left the synopsis default at `8.3` and the dead `'8.2'` literal untouched.

## Changes

- **Default bumped to 8.4** — `--php` synopsis `default: 8.3` → `default: 8.4`, so new sites match the `8.4` image already used for the `latest` tag and the 8.x fallback.
- **Dead code removed** — dropped the `'8.2'` fallback argument from the `--php` `get_flag_value()` call. WP-CLI injects the synopsis `default:` into the args before the command runs, so the literal never executed; it only served to confuse and drift from the real default. The synopsis is now the single source of truth.

## Notes

- No behaviour change from removing the fallback: `$assoc_args['php']` is always populated from the synopsis `default:` by the time `create()` runs.
- PHP 8.4 is already a supported version and its image (`easyengine/php8.4`) is already referenced, so no new image wiring is required.
