### PR TITLE
docs: regenerate README for current PHP version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,21 @@ ee site create --type=wp <site-name> [--cache] [--vip] [--mu=<subdir>] [--mu=<su
 		Enable cache with local redis container.
 
 	[--php=<php-version>]
-		PHP version for site. Currently only supports PHP 5.6 and latest.
+		PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 and latest.
 		---
-		default: latest
+		default: 8.4
 		options:
 			- 5.6
+			- 7.0
 			- 7.2
+			- 7.3
+			- 7.4
+			- 8.0
+			- 8.1
+			- 8.2
+			- 8.3
+			- 8.4
+			- 8.5
 			- latest
 		---
 
@@ -246,12 +255,21 @@ ee site info --type=wp <site-name> [--cache] [--vip] [--mu=<subdir>] [--mu=<subd
 		Enable cache with local redis container.
 
 	[--php=<php-version>]
-		PHP version for site. Currently only supports PHP 5.6 and latest.
+		PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 and latest.
 		---
-		default: latest
+		default: 8.4
 		options:
 			- 5.6
+			- 7.0
 			- 7.2
+			- 7.3
+			- 7.4
+			- 8.0
+			- 8.1
+			- 8.2
+			- 8.3
+			- 8.4
+			- 8.5
 			- latest
 		---
 
@@ -518,12 +536,21 @@ ee site reload --type=wp <site-name> [--cache] [--vip] [--mu=<subdir>] [--mu=<su
 		Enable cache with local redis container.
 
 	[--php=<php-version>]
-		PHP version for site. Currently only supports PHP 5.6 and latest.
+		PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 and latest.
 		---
-		default: latest
+		default: 8.4
 		options:
 			- 5.6
+			- 7.0
 			- 7.2
+			- 7.3
+			- 7.4
+			- 8.0
+			- 8.1
+			- 8.2
+			- 8.3
+			- 8.4
+			- 8.5
 			- latest
 		---
 
@@ -653,12 +680,21 @@ ee site restart --type=wp <site-name> [--cache] [--vip] [--mu=<subdir>] [--mu=<s
 		Enable cache with local redis container.
 
 	[--php=<php-version>]
-		PHP version for site. Currently only supports PHP 5.6 and latest.
+		PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 and latest.
 		---
-		default: latest
+		default: 8.4
 		options:
 			- 5.6
+			- 7.0
 			- 7.2
+			- 7.3
+			- 7.4
+			- 8.0
+			- 8.1
+			- 8.2
+			- 8.3
+			- 8.4
+			- 8.5
 			- latest
 		---
 


### PR DESCRIPTION
## Summary

The `--php` option sections in the generated README were badly out of date — they listed **only PHP 5.6 and latest** with a default of **latest**, while the command has long supported PHP 5.6–8.5 and now defaults to **8.4**.

This syncs the README's `--php` blocks (all occurrences) with the current command docblock:

- Supported versions: `5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, latest`
- `default: 8.4`

## Notes

- README is generated via `ee scaffold package-readme`; this change reproduces exactly what the scaffold emits from the current `--php` docblock, so a future scaffold run is a no-op against it.
- Docs-only change — no code is touched.
